### PR TITLE
Update the checkout action to v3 to eliminate Node v12 deprecation warning.

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,7 +15,7 @@ jobs:
           - '3.2.0'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - '3.2.0'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Eliminating this warning:

<img width="1375" alt="Screenshot 2023-04-25 at 3 22 15 PM" src="https://user-images.githubusercontent.com/421488/234381241-7d9dfa3f-c6ce-40dd-9e6d-8c48c27b3659.png">
