### PR TITLE
Support queue_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ class MyWorker
   include Sidekiq::Worker
   include Sidekiq::AWS::SQS::Worker
 
-  sqs_options queue_url: 'https://sqs.foo.amazonaws.com/123/bar',
+  sqs_options queue_url: 'https://sqs.foo.amazonaws.com/123/bar', # Requires either queue_url or queue_name
+              queue_name: 'foo_bar', # alternative to queue_url
               wait_time_seconds: 20, # optional, default: 20
               destroy_on_received: true, # optional, default: false
               max_number_of_messages: 10, # optional, default: 10

--- a/lib/sidekiq/aws/sqs/helpers.rb
+++ b/lib/sidekiq/aws/sqs/helpers.rb
@@ -58,7 +58,7 @@ module Sidekiq
         end
 
         def need_to_raise_for_queue_url?
-          @sqs_options[:queue_url].blank? && !@sqs_options[:queue_name].blank?
+          @sqs_options[:queue_url].blank? && @sqs_options[:queue_name].blank?
         end
 
         def need_to_raise_for_destroy_on_received?

--- a/lib/sidekiq/aws/sqs/helpers.rb
+++ b/lib/sidekiq/aws/sqs/helpers.rb
@@ -30,27 +30,14 @@ module Sidekiq
         end
 
         def sqs_options_struct
-          if @sqs_options[:wait_time_seconds].blank?
-            @sqs_options[:wait_time_seconds] =
-              Sidekiq::AWS::SQS.config.wait_time_seconds
-          end
-
-          if @sqs_options[:max_number_of_messages].blank?
-            @sqs_options[:max_number_of_messages] =
-              Sidekiq::AWS::SQS.config.max_number_of_messages
-          end
-
-          if @sqs_options[:destroy_on_received].blank?
-            @sqs_options[:destroy_on_received] =
-              Sidekiq::AWS::SQS.config.destroy_on_received
-          end
-
           @sqs_options[:client] ||= Sidekiq::AWS::SQS.config.sqs_client
+          @sqs_options[:wait_time_seconds] ||= Sidekiq::AWS::SQS.config.wait_time_seconds
+          @sqs_options[:max_number_of_messages] ||= Sidekiq::AWS::SQS.config.max_number_of_messages
+          @sqs_options[:destroy_on_received] ||= Sidekiq::AWS::SQS.config.destroy_on_received
 
-          if @sqs_options[:queue_name].present?
-            @sqs_options[:queue_url] ||= @sqs_options[:client].get_queue_url(
-              queue_name: @sqs_options[:queue_name]
-            ).queue_url
+          if @sqs_options[:queue_name].present? && @sqs_options[:queue_url].blank?
+            queue_url = @sqs_options[:client].get_queue_url(queue_name: @sqs_options[:queue_name]).queue_url
+            @sqs_options[:queue_url] = queue_url
           end
 
           OpenStruct.new(@sqs_options)


### PR DESCRIPTION
Add support for `queue_name` as an alternative to `queue_url`. We store the names rather then the entire url. 

Getting the actual url within the `sqs_options` block becomes quite messy.

Let me know what you think